### PR TITLE
Thread safety

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org/'
 
 gemspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,54 +3,51 @@ PATH
   specs:
     ruote-postgres (0.0.1)
       json
-      pg (= 0.14.1)
+      pg
       rake
       ruote
       yajl-ruby
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     blankslate (2.1.2.4)
-    columnize (0.3.6)
-    debugger (1.2.2)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.1.1)
-      debugger-ruby_core_source (~> 1.1.5)
-    debugger-linecache (1.1.2)
-      debugger-ruby_core_source (>= 1.1.1)
-    debugger-ruby_core_source (1.1.5)
-    diff-lcs (1.1.3)
-    file-tail (1.0.12)
-      tins (~> 0.5)
-    json (1.7.6)
+    diff-lcs (1.2.5)
+    file-tail (1.1.0)
+      tins (~> 1.0)
+    json (1.8.3)
     parslet (1.4.0)
       blankslate (~> 2.0)
-    pg (0.14.1)
-    rake (10.0.3)
-    rspec (2.12.0)
-      rspec-core (~> 2.12.0)
-      rspec-expectations (~> 2.12.0)
-      rspec-mocks (~> 2.12.0)
-    rspec-core (2.12.2)
-    rspec-expectations (2.12.1)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.12.2)
+    pg (0.18.4)
+    rake (11.1.2)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
     ruby2ruby (1.3.1)
       ruby_parser (~> 2.0)
       sexp_processor (~> 3.0)
     ruby_parser (2.3.1)
       sexp_processor (~> 3.0)
-    rufus-cloche (1.0.2)
-      rufus-json (>= 1.0.1)
+    rufus-cloche (1.0.4)
+      rufus-json (>= 1.0.3)
     rufus-dollar (1.0.4)
-    rufus-json (1.0.2)
+    rufus-json (1.0.6)
     rufus-mnemo (1.2.3)
-    rufus-scheduler (2.0.17)
-      tzinfo (>= 0.3.23)
+    rufus-scheduler (2.0.24)
+      tzinfo (>= 0.3.22)
     rufus-treechecker (1.0.8)
       ruby_parser (>= 2.0.5)
-    ruote (2.3.0.2)
+    ruote (2.3.0.3)
       blankslate (= 2.1.2.4)
       parslet (= 1.4.0)
       ruby_parser (~> 2.3)
@@ -58,7 +55,7 @@ GEM
       rufus-dollar (>= 1.0.4)
       rufus-json (>= 1.0.1)
       rufus-mnemo (>= 1.2.2)
-      rufus-scheduler (>= 2.0.16)
+      rufus-scheduler (= 2.0.24)
       rufus-treechecker (>= 1.0.8)
       sourcify (= 0.5.0)
     sexp_processor (3.2.0)
@@ -67,14 +64,18 @@ GEM
       ruby2ruby (>= 1.2.5)
       ruby_parser (>= 2.0.5)
       sexp_processor (>= 3.0.5)
-    tins (0.7.0)
-    tzinfo (0.3.35)
-    yajl-ruby (1.1.0)
+    thread_safe (0.3.5)
+    tins (1.9.0)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    yajl-ruby (1.2.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  debugger
   rspec
   ruote-postgres!
+
+BUNDLED WITH
+   1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,9 @@ PATH
   remote: .
   specs:
     ruote-postgres (0.0.1)
-      json
       pg
       rake
       ruote
-      yajl-ruby
 
 GEM
   remote: https://rubygems.org/
@@ -15,7 +13,6 @@ GEM
     diff-lcs (1.2.5)
     file-tail (1.1.0)
       tins (~> 1.0)
-    json (1.8.3)
     parslet (1.4.0)
       blankslate (~> 2.0)
     pg (0.18.4)
@@ -68,7 +65,6 @@ GEM
     tins (1.9.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    yajl-ruby (1.2.1)
 
 PLATFORMS
   ruby

--- a/README.mdown
+++ b/README.mdown
@@ -8,7 +8,7 @@ This is how a ruote engine is setup with a ruote-postgres storage and a worker :
 
 ```ruby
 require 'rubygems'
-require 'json' # gem install json
+require 'json'
 require 'ruote'
 require 'ruote-postgres' # gem install ruote-postgres
 

--- a/lib/ruote/postgres/storage.rb
+++ b/lib/ruote/postgres/storage.rb
@@ -23,12 +23,7 @@
 # Made in Roma.
 #++
 
-begin
-  require 'yajl'
-rescue LoadError => le
-  require 'json'
-end
-
+require 'json'
 require 'pg'
 require 'rufus/json'
 require 'ruote/storage/base'

--- a/lib/ruote/postgres/storage.rb
+++ b/lib/ruote/postgres/storage.rb
@@ -43,7 +43,6 @@ module Postgres
   # something else with the optional third parameter
   #
   def self.create_table(pg, re_create=false, table_name='documents')
-
     table_exists = table_exists?(pg, table_name)
 
     pg.exec("DROP TABLE #{table_name}") if re_create && table_exists
@@ -60,7 +59,6 @@ module Postgres
       pg.exec("CREATE INDEX #{table_name}_wfid_index ON #{table_name} USING btree (wfid)")
       pg.exec("ALTER TABLE ONLY #{table_name} ADD CONSTRAINT #{table_name}_pkey PRIMARY KEY (typ, ide, rev)")
     end
-
   end
 
   def self.table_exists?(pg, table_name)
@@ -104,12 +102,11 @@ module Postgres
     # The underlying Postgres::Database instance
     #
     attr_reader :pg
-    attr_reader :pg_channel
 
     def initialize(pg, options={})
-      @pg         = pg
-      @pg_channel = "ruote_postgres"
-      @table      = (options['pg_table_name'] || :documents).to_sym
+      @mutex = Mutex.new
+      @pg    = pg
+      @table = (options['pg_table_name'] || :documents).to_sym
 
       replace_engine_configuration(options)
     end
@@ -150,10 +147,12 @@ module Postgres
         return (get(doc['type'], doc['_id']) || true) # failure
       end
 
-      @pg.exec(%{DELETE FROM #{@table}
-                 WHERE typ='#{doc['type']}' AND
-                       ide='#{doc['_id']}' AND
-                       rev<#{nrev}})
+      @mutex.synchronize do
+        @pg.exec(%{DELETE FROM #{@table}
+                   WHERE typ='#{doc['type']}' AND
+                         ide='#{doc['_id']}' AND
+                         rev<#{nrev}})
+      end
 
       nil # success
     end
@@ -165,11 +164,13 @@ module Postgres
     def delete(doc)
       raise ArgumentError.new('no _rev for doc') unless doc['_rev']
 
-      count = @pg.exec(%{DELETE FROM #{@table}
-                         WHERE typ='#{doc['type']}' AND
-                               ide='#{doc['_id']}' AND
-                               rev=#{doc['_rev'].to_i}
-                         RETURNING *}).count
+      count = @mutex.synchronize do
+        @pg.exec(%{DELETE FROM #{@table}
+                    WHERE typ='#{doc['type']}' AND
+                          ide='#{doc['_id']}' AND
+                          rev=#{doc['_rev'].to_i}
+                    RETURNING *}).count
+      end
 
       return (get(doc['type'], doc['_id']) || true) if count < 1 # failure
 
@@ -183,13 +184,19 @@ module Postgres
 
       ds += " AND wfid in ('#{keys.join("','")}') " if keys && keys.first.is_a?(String)
 
-      return @pg.exec("SELECT count(*) as count" + ds)[0]["count"].to_i if opts[:count]
+      if opts[:count]
+        return @mutex.synchronize do
+          @pg.exec("SELECT count(*) as count" + ds)[0]["count"].to_i
+        end
+      end
 
       ds += " ORDER BY ide #{opts[:descending] ? "DESC" : "ASC"}, rev DESC"
       ds += " LIMIT #{opts[:limit]} " if opts[:limit]
       ds += " OFFSET #{opts[:skip] || opts[:offset]} " if opts[:skip] || opts[:offset]
 
-      docs = @pg.exec("SELECT * " + ds).collect { |d| decode_doc(d) }
+      docs = @mutex.synchronize do
+        @pg.exec("SELECT * " + ds).collect { |d| decode_doc(d) }
+      end
 
       if keys && keys.first.is_a?(Regexp)
         docs.select { |doc| keys.find { |key| key.match(doc['_id']) } }
@@ -204,15 +211,19 @@ module Postgres
     # Returns all the ids of the documents of a given type.
     #
     def ids(type)
-      @pg.exec(%{SELECT DISTINCT(ide) FROM #{@table}
-                 WHERE typ='#{type}'
-                 ORDER BY ide}).collect{|row| row["ide"]}
+      @mutex.synchronize do
+        @pg.exec(%{SELECT DISTINCT(ide) FROM #{@table}
+                   WHERE typ='#{type}'
+                   ORDER BY ide}).collect{|row| row["ide"]}
+      end
     end
 
     # Nukes all the documents in this storage.
     #
     def purge!
-      @pg.exec("DELETE FROM #{@table}")
+      @mutex.synchronize do
+        @pg.exec("DELETE FROM #{@table}")
+      end
     end
     alias :clear :purge!
 
@@ -225,7 +236,9 @@ module Postgres
     # Nukes a db type and reputs it (losing all the documents that were in it).
     #
     def purge_type!(type)
-      @pg.exec("DELETE FROM #{@table} WHERE typ='#{type}'")
+      @mutex.synchronize do
+        @pg.exec("DELETE FROM #{@table} WHERE typ='#{type}'")
+      end
     end
 
     protected
@@ -243,10 +256,12 @@ module Postgres
       def do_insert(doc, rev, update_rev=false)
         doc = doc.send( update_rev ? :merge! : :merge, { '_rev' => rev, 'put_at' => Ruote.now_to_utc_s })
 
-        @pg.exec_params(
-          "INSERT INTO #{@table}(ide, rev, typ, doc, wfid, participant_name) VALUES($1, $2::int, $3, $4, $5, $6)",
-          [ doc['_id'], (rev || 1), doc['type'], (Rufus::Json.encode(doc) || ''), (extract_wfid(doc) || ''), (doc['participant_name'] || '') ]
-        )
+        @mutex.synchronize do
+          @pg.exec_params(
+            "INSERT INTO #{@table}(ide, rev, typ, doc, wfid, participant_name) VALUES($1, $2::int, $3, $4, $5, $6)",
+            [ doc['_id'], (rev || 1), doc['type'], (Rufus::Json.encode(doc) || ''), (extract_wfid(doc) || ''), (doc['participant_name'] || '') ]
+          )
+        end
       end
 
       def extract_wfid(doc)
@@ -254,17 +269,21 @@ module Postgres
       end
 
       def do_get(type, key)
-        d = @pg.exec(%{SELECT doc FROM #{@table}
-                       WHERE typ='#{type}' AND
-                             ide='#{key}'
-                       ORDER BY rev DESC
-                       LIMIT 1 OFFSET 0})
+        d = @mutex.synchronize do
+          @pg.exec(%{SELECT doc FROM #{@table}
+                     WHERE typ='#{type}' AND
+                           ide='#{key}'
+                     ORDER BY rev DESC
+                     LIMIT 1 OFFSET 0})
+        end
 
         decode_doc(d[0]) if d.count > 0
       end
 
       def server_version
-        @server_version ||= @pg.exec("show server_version")[0]["server_version"].split(".").map(&:to_i)
+        @server_version ||= @mutex.synchronize do
+          @pg.exec("show server_version")[0]["server_version"].split(".").map(&:to_i)
+        end
       end
 
       def has_json?

--- a/ruote-postgres.gemspec
+++ b/ruote-postgres.gemspec
@@ -8,6 +8,8 @@ Gem::Specification.new do |s|
     File.expand_path('../lib/ruote/postgres/version.rb', __FILE__)
   ).match(/ VERSION *= *['"]([^'"]+)/)[1]
 
+  s.required_ruby_version = '>= 1.9.3'
+
   s.platform = Gem::Platform::RUBY
   s.authors = [ 'Lleir Borras Metje' ]
   s.email = [ 'l.borrasmetje@ifad.org' ]
@@ -28,8 +30,6 @@ LISTEN and NOTIFY to watch for events.
 
   s.add_dependency 'rake'
   s.add_dependency 'pg'
-  s.add_dependency 'yajl-ruby'
-  s.add_dependency 'json'
 
   s.require_path = 'lib'
 end

--- a/ruote-postgres.gemspec
+++ b/ruote-postgres.gemspec
@@ -31,8 +31,6 @@ LISTEN and NOTIFY to watch for events.
   s.add_dependency 'yajl-ruby'
   s.add_dependency 'json'
 
-  s.add_development_dependency 'debugger'
-
   s.require_path = 'lib'
 end
 

--- a/spec/unit/postgres_spec.rb
+++ b/spec/unit/postgres_spec.rb
@@ -13,7 +13,7 @@ describe Ruote::Postgres do
 
     describe "with default arguments" do
       it "queries if the table exist" do
-        klass.should_receive(:table_exists?).with(pg, table_name)
+        expect(klass).to receive(:table_exists?).with(pg, table_name)
         klass.create_table(pg)
       end
 
@@ -21,13 +21,13 @@ describe Ruote::Postgres do
         create_table(pg, table_name)
         klass.create_table(pg)
 
-        columns(pg, table_name).should =~ %w{ ide }
+        expect(columns(pg, table_name)).to match_array(%w{ ide })
       end
 
       it "it creates the table" do
         klass.create_table(pg)
 
-        columns(pg, table_name).should =~ %w{ ide rev typ doc wfid participant_name }
+        expect(columns(pg, table_name)).to match_array(%w{ ide rev typ doc wfid participant_name })
       end
     end
 
@@ -36,7 +36,7 @@ describe Ruote::Postgres do
         create_table(pg, table_name)
         klass.create_table(pg, true)
 
-        columns(pg, table_name).should =~ %w{ ide rev typ doc wfid participant_name }
+        expect(columns(pg, table_name)).to match_array(%w{ ide rev typ doc wfid participant_name })
       end
     end
 
@@ -46,7 +46,7 @@ describe Ruote::Postgres do
       it "it removes the table if it already exist" do
         klass.create_table(pg, false, table_name)
 
-        columns(pg, table_name).should =~ %w{ ide rev typ doc wfid participant_name }
+        expect(columns(pg, table_name)).to match_array(%w{ ide rev typ doc wfid participant_name })
       end
     end
   end
@@ -54,11 +54,11 @@ describe Ruote::Postgres do
   describe "#table_exists?" do
     it "returns true if it exists" do
       create_table(pg, table_name)
-      klass.table_exists?(pg, table_name).should be_true
+      expect(klass.table_exists?(pg, table_name)).to be_truthy
     end
 
     it "returns false if it doesn't exist" do
-      klass.table_exists?(pg, table_name).should be_false
+      expect(klass.table_exists?(pg, table_name)).to be_falsey
     end
   end
 end

--- a/spec/unit/storage_spec.rb
+++ b/spec/unit/storage_spec.rb
@@ -10,36 +10,36 @@ describe Ruote::Postgres::Storage do
 
   describe "#initialize" do
     before do
-      Ruote::Postgres::Storage.any_instance.stub(:replace_engine_configuration)
+      allow_any_instance_of(Ruote::Postgres::Storage).to receive(:replace_engine_configuration)
     end
 
     it "prepares the storage" do
-      Ruote::Postgres::Storage.any_instance.should_receive(:replace_engine_configuration)
+      expect_any_instance_of(Ruote::Postgres::Storage).to receive(:replace_engine_configuration)
       Ruote::Postgres::Storage.new(pg)
     end
 
     it "prepares the storage with options" do
       options = {a: :b}
 
-      Ruote::Postgres::Storage.any_instance.should_receive(:replace_engine_configuration).with(options)
+      expect_any_instance_of(Ruote::Postgres::Storage).to receive(:replace_engine_configuration).with(options)
       Ruote::Postgres::Storage.new(pg, options)
     end
 
     it "assigns the db connection" do
       storage = Ruote::Postgres::Storage.new(pg)
-      storage.instance_variable_get(:@pg).should == pg
+      expect(storage.instance_variable_get(:@pg)).to eq(pg)
     end
 
     it "assigns the table with default value" do
       storage = Ruote::Postgres::Storage.new(pg)
-      storage.instance_variable_get(:@table).should == :documents
+      expect(storage.instance_variable_get(:@table)).to eq(:documents)
     end
 
     it "assigns the table name" do
       options = {'pg_table_name' => "some_table_name"}
 
       storage = Ruote::Postgres::Storage.new(pg, options)
-      storage.instance_variable_get(:@table).should == :some_table_name
+      expect(storage.instance_variable_get(:@table)).to eq(:some_table_name)
     end
   end
 
@@ -50,24 +50,24 @@ describe Ruote::Postgres::Storage do
       context "with new document" do
         it "works" do
           p subject.put({ "type" => "expressions", "_id" => "1" })
-          pg.query("select * from documents").values.should_not be_empty
+          expect(pg.query("select * from documents").values).not_to be_empty
         end
       end
 
       it "returns true if the document has been deleted from the store" do
-        subject.put({"type" => "expressions", "_id" => "4", "_rev" => 1}).should be_true
+        expect(subject.put({"type" => "expressions", "_id" => "4", "_rev" => 1})).to be_truthy
       end
 
       it "returns a document if the revision has changed" do
         doc = insert(pg, table_name, typ: 'expressions', ide: '4', wfid: "ef5678", rev: 2, doc: {"e" => "f"})
 
-        subject.put({"type" => "expressions", "_id" => "4", "_rev" => 1}).should == doc
+        expect(subject.put({"type" => "expressions", "_id" => "4", "_rev" => 1})).to eq(doc)
       end
 
       it "returns nil when the document is successfully stored" do
         insert(pg, table_name, typ: 'expressions', ide: '4', wfid: "ef5678", rev: 1, doc: {"e" => "f"})
 
-        subject.put({"type" => "expressions", "_id" => "4", "_rev" => 1}).should be_nil
+        expect(subject.put({"type" => "expressions", "_id" => "4", "_rev" => 1})).to be_nil
       end
 
     end
@@ -76,7 +76,7 @@ describe Ruote::Postgres::Storage do
       it "returns the document that matches the given type ans key" do
         doc =  insert(pg, table_name, typ: 'msgs', ide: '1')
 
-        subject.get('msgs', '1').should == doc
+        expect(subject.get('msgs', '1')).to eq(doc)
       end
     end
 
@@ -88,17 +88,17 @@ describe Ruote::Postgres::Storage do
       end
 
       it "returns true if already deleted" do
-        subject.delete({"type" => "expressions", "_id" => "4", "_rev" => 1}).should be_true
+        expect(subject.delete({"type" => "expressions", "_id" => "4", "_rev" => 1})).to be_truthy
       end
 
       it "returns a document if the revision of the given document doesn't match the version of the stored document" do
         doc = insert(pg, table_name, typ: 'expressions', ide: '4', wfid: "ef5678", rev: 2, doc: {"e" => "f"})
 
-        subject.delete({"type" => "expressions", "_id" => "4", "_rev" => 1}).should == doc
+        expect(subject.delete({"type" => "expressions", "_id" => "4", "_rev" => 1})).to eq(doc)
       end
 
       it "returns nil when successfully removed" do
-        subject.delete({"type" => "expressions", "_id" => "3", "_rev" => 1}).should be_nil
+        expect(subject.delete({"type" => "expressions", "_id" => "3", "_rev" => 1})).to be_nil
       end
     end
 
@@ -111,50 +111,50 @@ describe Ruote::Postgres::Storage do
 
       describe "without opts" do
         it "return an array of matching documents whitout any opts" do
-          subject.get_many("expressions").should =~ [{"type" => "expressions", "_id" => "3", "_rev" => 1, "c" => "d"},
-                                                     {"type" => "expressions", "_id" => "2", "_rev" => 1, "a" => "b"}]
+          expect(subject.get_many("expressions")).to match_array([{"type" => "expressions", "_id" => "3", "_rev" => 1, "c" => "d"},
+                                                     {"type" => "expressions", "_id" => "2", "_rev" => 1, "a" => "b"}])
         end
       end
 
       describe "with opts" do
         describe ":count" do
           it "returns the number of matching documents without explicit key as an integer" do
-            subject.get_many("expressions", nil, count: true).should == 2
+            expect(subject.get_many("expressions", nil, count: true)).to eq(2)
           end
 
           it "returns the number of matching documents with a matching key as an integer" do
-            subject.get_many("expressions", "cd34", count: true).should == 1
+            expect(subject.get_many("expressions", "cd34", count: true)).to eq(1)
           end
         end
 
         describe ":descending" do
           it "returns the list sorted by ide descending" do
-            subject.get_many("expressions", nil, descending: true).should =~ [{"type" => "expressions", "_id" => "3", "_rev" => 1, "c" => "d"},
-                                                                              {"type" => "expressions", "_id" => "2", "_rev" => 1, "a" => "b"}]
+            expect(subject.get_many("expressions", nil, descending: true)).to match_array([{"type" => "expressions", "_id" => "3", "_rev" => 1, "c" => "d"},
+                                                                              {"type" => "expressions", "_id" => "2", "_rev" => 1, "a" => "b"}])
           end
 
           it "returns the list sorted by ide descending with an explicit key" do
-            subject.get_many("expressions", "cd34", descending: true).should =~ [{"type" => "expressions", "_id" => "2", "_rev" => 1, "a" => "b"}]
+            expect(subject.get_many("expressions", "cd34", descending: true)).to match_array([{"type" => "expressions", "_id" => "2", "_rev" => 1, "a" => "b"}])
           end
         end
 
         describe ":skip" do
           it "returns the list skiping some results" do
-            subject.get_many("expressions", nil, skip: 1).should =~ [{"type" => "expressions", "_id" => "3", "_rev" => 1, "c" => "d"}]
+            expect(subject.get_many("expressions", nil, skip: 1)).to match_array([{"type" => "expressions", "_id" => "3", "_rev" => 1, "c" => "d"}])
           end
 
           it "returns the list skiping some reslts with an explicit key" do
-            subject.get_many("expressions", "cd34", skip: 1).should =~ []
+            expect(subject.get_many("expressions", "cd34", skip: 1)).to match_array([])
           end
         end
 
         describe ":limit" do
           it "returns the list limiting some results" do
-            subject.get_many("expressions", nil, limit: 1).should =~ [{"type" => "expressions", "_id" => "2", "_rev" => 1, "a" => "b"}]
+            expect(subject.get_many("expressions", nil, limit: 1)).to match_array([{"type" => "expressions", "_id" => "2", "_rev" => 1, "a" => "b"}])
           end
 
           it "returns the list limiting some reslts with an explicit key" do
-            subject.get_many("expressions", "cd34", limit: 1).should =~ [{"type" => "expressions", "_id" => "2", "_rev" => 1, "a" => "b"}]
+            expect(subject.get_many("expressions", "cd34", limit: 1)).to match_array([{"type" => "expressions", "_id" => "2", "_rev" => 1, "a" => "b"}])
           end
         end
       end
@@ -168,7 +168,7 @@ describe Ruote::Postgres::Storage do
       end
 
       it "returns a list of id's for the matching documents" do
-        subject.ids("expressions").should =~ [ '2', '3' ]
+        expect(subject.ids("expressions")).to match_array([ '2', '3' ])
       end
     end
 
@@ -182,7 +182,7 @@ describe Ruote::Postgres::Storage do
       it "removes all the documents" do
         subject.clear
 
-        count(pg, table_name).should == 0
+        expect(count(pg, table_name)).to eq(0)
       end
     end
 
@@ -196,7 +196,7 @@ describe Ruote::Postgres::Storage do
       it "cleans the store" do
         subject.purge!
 
-        count(pg, table_name).should == 0
+        expect(count(pg, table_name)).to eq(0)
       end
     end
 
@@ -218,7 +218,7 @@ describe Ruote::Postgres::Storage do
       it "cleans the store for the given type" do
         subject.purge_type!("expressions")
 
-        count(pg, table_name, "WHERE typ='expressions'").should == 0
+        expect(count(pg, table_name, "WHERE typ='expressions'")).to eq(0)
       end
     end
   end


### PR DESCRIPTION
The PG gem on it's own is not thread safe, so when calling this backend from concurrent threads (e.g. Sidekiq or forking in Ruote), you'll get strange exceptions like this:

* PG::UnableToSend: extraneous data in "T" message
* PG::UnableToSend: connection not open

This adds a mutex around all `PG#exec` calls to make it thread safe. The Sequel backend uses a connection pool which will be more performant, but at least in our use case that won't be an issue.

All the specs here pass, but I'd like to run it against the Ruote test suite too. However on my setup with the default in-memory backend a lot of the Ruote tests fail. Any ideas @vjt @lleirborras?